### PR TITLE
Add Glfw.Windows.Window.Set_Cursor_Hidden 

### DIFF
--- a/src/glfw/v3/glfw-windows.adb
+++ b/src/glfw/v3/glfw-windows.adb
@@ -18,6 +18,7 @@ with Ada.Unchecked_Conversion;
 
 with Glfw.API;
 with Glfw.Enums;
+with Glfw.Input.Mouse;
 
 package body Glfw.Windows is
    procedure Raw_Position_Callback (Raw  : System.Address;
@@ -288,6 +289,16 @@ package body Glfw.Windows is
       API.Set_Window_Should_Close (Object.Handle, Bool (Value));
    end Set_Should_Close;
 
+   procedure Set_Cursor_Hidden (Object : not null access Window;
+                                Cursor_Hidden:  Boolean) is
+   begin
+      if Cursor_Hidden then
+         API.Set_Input_Mode (Object.Handle, Enums.Mouse_Cursor, Glfw.Input.Mouse.Hidden);
+	  else
+	     API.Set_Input_Mode (Object.Handle, Enums.Mouse_Cursor, Glfw.Input.Mouse.Normal);
+      end if;
+   end Set_Cursor_Hidden;
+   
    procedure Enable_Callback (Object  : not null access Window;
                               Subject : Callbacks.Kind) is
    begin

--- a/src/glfw/v3/glfw-windows.ads
+++ b/src/glfw/v3/glfw-windows.ads
@@ -89,6 +89,9 @@ package Glfw.Windows is
    procedure Set_Should_Close (Object : not null access Window;
                                Value  : Boolean);
 
+   procedure Set_Cursor_Hidden (Object : not null access Window;
+                                Cursor_Hidden : Boolean);
+
    -----------------------------------------------------------------------------
    -- Event API
    -----------------------------------------------------------------------------


### PR DESCRIPTION
Adds the ability to hide the mouse cursor for a window

I am not very familiar with Ada so I took the liberty of not wrapping the original GLFW3 API but wrote a dedicated procedure for hiding the cursor instead.

