### PR TITLE
Conflict removal

### DIFF
--- a/examples/ogl_tutorials/05_textured_cube/src/main_loop.adb
+++ b/examples/ogl_tutorials/05_textured_cube/src/main_loop.adb
@@ -160,7 +160,7 @@ procedure Main_Loop (Main_Window : in out Glfw.Windows.Window) is
 
         UVs_Buffer.Initialize_Id;
         Array_Buffer.Bind (UVs_Buffer);
-        Utilities.Load_UV_Buffer (Array_Buffer, Cube_Data.UV_Data, Static_Draw);
+        Utilities.Load_Vertex_Buffer (Array_Buffer, Cube_Data.UV_Data, Static_Draw);
 
     exception
         when others =>

--- a/examples/ogl_tutorials/06_keyboard_mouse/src/main_loop.adb
+++ b/examples/ogl_tutorials/06_keyboard_mouse/src/main_loop.adb
@@ -156,7 +156,7 @@ procedure Main_Loop (Main_Window : in out Glfw.Windows.Window) is
 
         UVs_Buffer.Initialize_Id;
         Array_Buffer.Bind (UVs_Buffer);
-        Utilities.Load_UV_Buffer (Array_Buffer, Cube_Data.UV_Data, Static_Draw);
+        Utilities.Load_Vertex_Buffer (Array_Buffer, Cube_Data.UV_Data, Static_Draw);
         Utilities.Enable_Mouse_Callbacks (Window, True);
         Window.Enable_Callback (Glfw.Windows.Callbacks.Char);
         Window.Enable_Callback (Glfw.Windows.Callbacks.Position);

--- a/examples/open_gl/simple_uniform/src/main_loop.adb
+++ b/examples/open_gl/simple_uniform/src/main_loop.adb
@@ -60,7 +60,7 @@ procedure Main_Loop (Main_Window : in out Glfw.Windows.Window) is
 
         Vertex_Buffer.Initialize_Id;
         Array_Buffer.Bind (Vertex_Buffer);
-        Utilities.Load_UV_Buffer (Array_Buffer, Vertex_data.Vertices, Static_Draw);
+        Utilities.Load_Vertex_Buffer (Array_Buffer, Vertex_data.Vertices, Static_Draw);
 
         Rendering_Program := Program_From
           ((Src ("src/shaders/vertex_shader.glsl", Vertex_Shader),


### PR DESCRIPTION
Conflicts removed from examples.
All examples rebuilt and run successfully except for Durian Buffers and Textures which fails due to a problem with SOIL.
opengl-soil.gpr fails to build due to a problem with System/Library/Frameworks/Core.Foundation/Headers/CFDateFormatter.