### PR TITLE
Add initial support for shader storage buffer objects

### DIFF
--- a/src/gl/implementation/gl-low_level-enums.ads
+++ b/src/gl/implementation/gl-low_level-enums.ads
@@ -28,7 +28,8 @@ package GL.Low_Level.Enums is
                         Pixel_Unpack_Buffer, Uniform_Buffer, Texture_Buffer,
                         Transform_Feedback_Buffer, Transform_Feedback,
                         Copy_Read_Buffer, Copy_Write_Buffer,
-                        Draw_Indirect_Buffer, Atomic_Counter_Buffer);
+                        Draw_Indirect_Buffer, Shader_Storage_Buffer,
+                        Atomic_Counter_Buffer);
 
    type Draw_Buffer_Index is (DB0, DB1, DB2, DB3, DB4, DB5, DB6, DB7,
       DB8, DB9, DB10, DB11, DB12, DB13, DB14, DB15);
@@ -82,6 +83,7 @@ private
                         Copy_Read_Buffer          => 16#8F36#,
                         Copy_Write_Buffer         => 16#8F37#,
                         Draw_Indirect_Buffer      => 16#8F3F#,
+                        Shader_Storage_Buffer     => 16#90D2#,
                         Atomic_Counter_Buffer     => 16#92C0#);
    for Buffer_Kind'Size use Enum'Size;
 

--- a/src/gl/interface/gl-objects-buffers.ads
+++ b/src/gl/interface/gl-objects-buffers.ads
@@ -140,6 +140,7 @@ package GL.Objects.Buffers is
    Copy_Read_Buffer          : constant Buffer_Target;
    Copy_Write_Buffer         : constant Buffer_Target;
    Draw_Indirect_Buffer      : constant Buffer_Target;
+   Shader_Storage_Buffer     : constant Buffer_Target;
    Atomic_Counter_Buffer     : constant Buffer_Target;
 
 private
@@ -205,6 +206,8 @@ private
      := Buffer_Target'(Kind => Low_Level.Enums.Copy_Write_Buffer);
    Draw_Indirect_Buffer      : constant Buffer_Target
      := Buffer_Target'(Kind => Low_Level.Enums.Draw_Indirect_Buffer);
+   Shader_Storage_Buffer     : constant Buffer_Target
+     := Buffer_Target'(Kind => Low_Level.Enums.Shader_Storage_Buffer);
    Atomic_Counter_Buffer     : constant Buffer_Target
      := Buffer_Target'(Kind => Low_Level.Enums.Atomic_Counter_Buffer);
 end GL.Objects.Buffers;


### PR DESCRIPTION
This very simple PR enables basic support for shader storage buffer objects ([SSBO](https://www.khronos.org/opengl/wiki/Shader_Storage_Buffer_Object)s).

The `0x90d2` value comes from [here](https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_shader_storage_buffer_object.txt).