### PR TITLE
Alire manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+alire/
+alire.lock
 lib
 obj
 bin

--- a/alire.toml
+++ b/alire.toml
@@ -1,0 +1,27 @@
+name = "openglada"
+version = "0.8.0"
+description = "Thick Ada binding for OpenGL and GLFW"
+website = "http://flyx.github.io/OpenGLAda/"
+authors = ["Felix Krause <contact@flyx.org>"]
+executables = ["gl_test-opengl3", "gl_test-context", "gl_test-vbos", "gl_test-shaders", "gl_test-framebuffers", "gl_test-immediate"]
+licenses = "MIT"
+maintainers = ["Felix Krause <contact@flyx.org>"]
+maintainers-logins = ["flyx"]
+tags = ["opengl", "glfw", "binding"]
+
+project-files = ["opengl.gpr", "opengl-glfw.gpr", "opengl-test.gpr"]
+
+[[depends-on]]
+[depends-on."case(os)".linux]
+libglfw3 = "^3"
+libx11 = "^1"
+
+[gpr-externals]
+Auto_Exceptions = ["enabled", "disabled"]
+GLFW_Version = ["2", "3"]
+Mode = ["debug", "release"]
+
+[gpr-set-externals."case(os)"]
+linux   = { Windowing_System = "x11" }
+macos   = { Windowing_System = "quartz" }
+windows = { Windowing_System = "windows" }


### PR DESCRIPTION
Having a manifest in place enables
- `alr build`ing the library
- `alr publish`ing new versions easily
- Using it as an unversioned dependency in other Alire crates (https://github.com/alire-project/alire/pull/715)

@flyx, I'd understand if you don't want this file in your top-level folder. In that case, it might be still worthy to have it in a separate branch for the above use cases.