### PR TITLE
Support raw mouse motion

### DIFF
--- a/opengl-glfw/src/glfw-api.ads
+++ b/opengl-glfw/src/glfw-api.ads
@@ -372,9 +372,9 @@ private package Glfw.API is
    -----------------------------------------------------------------------------
 
    function Get_Input_Mode (Window : System.Address;
-                            Mode : Enums.Input_Toggle) return Bool;
+                            Mode : Enums.Bool_Toggle) return Bool;
    function Get_Input_Mode (Window : System.Address;
-                            Mode : Enums.Input_Toggle)
+                            Mode : Enums.Cursor_Toggle)
                             return Input.Mouse.Cursor_Mode;
    pragma Import (Convention => C, Entity => Get_Input_Mode,
                   External_Name => "glfwGetInputMode");
@@ -383,10 +383,17 @@ private package Glfw.API is
                              Mode   : Input.Sticky_Toggle;
                              Value  : Bool);
    procedure Set_Input_Mode (Window : System.Address;
-                             Mode   : Enums.Input_Toggle;
+                             Mode   : Enums.Cursor_Toggle;
                              Value  : Input.Mouse.Cursor_Mode);
+   procedure Set_Input_Mode (Window : System.Address;
+                             Mode   : Enums.Bool_Toggle;
+                             Value  : Bool);
    pragma Import (Convention => C, Entity => Set_Input_Mode,
                   External_Name => "glfwSetInputMode");
+
+   function Raw_Mouse_Motion_Supported return Bool;
+   pragma Import (Convention => C, Entity => Raw_Mouse_Motion_Supported,
+                  External_Name => "glfwRawMouseMotionSupported");
 
    function Get_Key (Window : System.Address; Key : Input.Keys.Key)
                      return Input.Button_State;

--- a/opengl-glfw/src/glfw-api.ads
+++ b/opengl-glfw/src/glfw-api.ads
@@ -372,9 +372,9 @@ private package Glfw.API is
    -----------------------------------------------------------------------------
 
    function Get_Input_Mode (Window : System.Address;
-                            Mode : Enums.Bool_Toggle) return Bool;
+                            Mode : Enums.Bool_Input_Toggle) return Bool;
    function Get_Input_Mode (Window : System.Address;
-                            Mode : Enums.Cursor_Toggle)
+                            Mode : Enums.Cursor_Input_Toggle)
                             return Input.Mouse.Cursor_Mode;
    pragma Import (Convention => C, Entity => Get_Input_Mode,
                   External_Name => "glfwGetInputMode");
@@ -383,10 +383,10 @@ private package Glfw.API is
                              Mode   : Input.Sticky_Toggle;
                              Value  : Bool);
    procedure Set_Input_Mode (Window : System.Address;
-                             Mode   : Enums.Cursor_Toggle;
+                             Mode   : Enums.Cursor_Input_Toggle;
                              Value  : Input.Mouse.Cursor_Mode);
    procedure Set_Input_Mode (Window : System.Address;
-                             Mode   : Enums.Bool_Toggle;
+                             Mode   : Enums.Bool_Input_Toggle;
                              Value  : Bool);
    pragma Import (Convention => C, Entity => Set_Input_Mode,
                   External_Name => "glfwSetInputMode");

--- a/opengl-glfw/src/glfw-enums.ads
+++ b/opengl-glfw/src/glfw-enums.ads
@@ -56,9 +56,12 @@ private package Glfw.Enums is
                         Scale_To_Monitor       => 16#2200C#);
    for Window_Info'Size use Interfaces.C.int'Size;
 
-   type Input_Toggle is (Mouse_Cursor);
-   for Input_Toggle use (Mouse_Cursor         => 16#33001#);
+   type Input_Toggle is (Mouse_Cursor, Raw_Mouse_Motion);
+   for Input_Toggle use (Mouse_Cursor         => 16#33001#,
+                         Raw_Mouse_Motion     => 16#33005#);
    for Input_Toggle'Size use Interfaces.C.int'Size;
+   subtype Cursor_Toggle is Input_Toggle range Mouse_Cursor .. Mouse_Cursor;
+   subtype Bool_Toggle is Input_Toggle range Raw_Mouse_Motion .. Raw_Mouse_Motion;
 
    type Joystick_ID is (
       Joystick_1, Joystick_2, Joystick_3, Joystick_4, Joystick_5,

--- a/opengl-glfw/src/glfw-enums.ads
+++ b/opengl-glfw/src/glfw-enums.ads
@@ -56,12 +56,13 @@ private package Glfw.Enums is
                         Scale_To_Monitor       => 16#2200C#);
    for Window_Info'Size use Interfaces.C.int'Size;
 
-   type Input_Toggle is (Mouse_Cursor, Raw_Mouse_Motion);
-   for Input_Toggle use (Mouse_Cursor         => 16#33001#,
-                         Raw_Mouse_Motion     => 16#33005#);
-   for Input_Toggle'Size use Interfaces.C.int'Size;
-   subtype Cursor_Toggle is Input_Toggle range Mouse_Cursor .. Mouse_Cursor;
-   subtype Bool_Toggle is Input_Toggle range Raw_Mouse_Motion .. Raw_Mouse_Motion;
+   type Cursor_Input_Toggle is (Mouse_Cursor);
+   for Cursor_Input_Toggle use (Mouse_Cursor   => 16#33001#);
+   for Cursor_Input_Toggle'Size use Interfaces.C.int'Size;
+
+   type Bool_Input_Toggle is (Raw_Mouse_Motion);
+   for Bool_Input_Toggle use (Raw_Mouse_Motion => 16#33005#);
+   for Bool_Input_Toggle'Size use Interfaces.C.int'Size;
 
    type Joystick_ID is (
       Joystick_1, Joystick_2, Joystick_3, Joystick_4, Joystick_5,

--- a/opengl-glfw/src/glfw-input-mouse.adb
+++ b/opengl-glfw/src/glfw-input-mouse.adb
@@ -1,0 +1,13 @@
+--  part of OpenGLAda, (c) 2017 Felix Krause
+--  released under the terms of the MIT license, see the file "COPYING"
+
+with Glfw.API;
+
+package body Glfw.Input.Mouse is
+
+   function Raw_Motion_Supported return Boolean is
+   begin
+      return Boolean (API.Raw_Mouse_Motion_Supported);
+   end Raw_Motion_Supported;
+
+end Glfw.Input.Mouse;

--- a/opengl-glfw/src/glfw-input-mouse.ads
+++ b/opengl-glfw/src/glfw-input-mouse.ads
@@ -16,6 +16,8 @@ package Glfw.Input.Mouse is
    subtype Coordinate is Interfaces.C.double;
    subtype Scroll_Offset is Interfaces.C.double;
 
+   function Raw_Motion_Supported return Boolean;
+
 private
    for Button'Size use Interfaces.C.int'Size;
 

--- a/opengl-glfw/src/glfw-windows.adb
+++ b/opengl-glfw/src/glfw-windows.adb
@@ -246,6 +246,12 @@ package body Glfw.Windows is
       API.Set_Cursor_Pos (Object.Handle, X, Y);
    end Set_Cursor_Pos;
 
+   procedure Set_Raw_Mouse_Motion (Object : not null access Window;
+                                   Value  : Boolean) is
+   begin
+      API.Set_Input_Mode (Object.Handle, Enums.Raw_Mouse_Motion, Bool (Value));
+   end Set_Raw_Mouse_Motion;
+
    procedure Get_Position (Object : not null access Window;
                            X, Y : out Coordinate) is
    begin

--- a/opengl-glfw/src/glfw-windows.ads
+++ b/opengl-glfw/src/glfw-windows.ads
@@ -59,6 +59,9 @@ package Glfw.Windows is
    procedure Set_Cursor_Mode (Object : not null access Window;
                               Mode   : Input.Mouse.Cursor_Mode);
 
+   procedure Set_Raw_Mouse_Motion (Object : not null access Window;
+                                   Value  : Boolean);
+
    procedure Get_Cursor_Pos (Object : not null access Window;
                              X, Y   : out Input.Mouse.Coordinate);
    procedure Set_Cursor_Pos (Object : not null access Window;


### PR DESCRIPTION
**When merged this pull request will:**

- Add an API binding to `glfwRawMouseMotionSupported`
- Refactor `Glfw.Enums.Input_Toggle` into two subtypes (cursor and bool toggles)
- Add a window procedure to enable/disable raw mouse motion

Requires Glfw 3.3 or higher.